### PR TITLE
Fix: Allow homepage access without login

### DIFF
--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -33,6 +33,7 @@ export async function updateSession(request: NextRequest) {
 
   if (
     !user &&
+  request.nextUrl.pathname !== '/' && // Allow access to the homepage
     !request.nextUrl.pathname.startsWith('/login') &&
     !request.nextUrl.pathname.startsWith('/auth')
   ) {


### PR DESCRIPTION
Modified the middleware to exclude the homepage from the authentication check. You can now view the homepage without being redirected to the login page. Other routes remain protected.